### PR TITLE
Update Sms77api.py

### DIFF
--- a/src/sms77api/Sms77api.py
+++ b/src/sms77api/Sms77api.py
@@ -10,19 +10,17 @@ from sms77api.classes.Pricing import PricingFormat
 from sms77api.classes.Subaccounts import SubaccountsAction
 
 
-def expect_json(endpoint: str, params: dict) -> bool:
-    if endpoint in [Endpoint.BALANCE.value, Endpoint.VOICE.value]:
-        return False
-    if 'json' not in params:
-        return False
-    if params['json'] is not True and params['json'] != 1:
-        return False
-    return True
-
-
-def local_params(locals_: dict) -> dict:
-    del locals_['self']
-    return locals_
+# 在 src/sms77api/Sms77api.py 文件中添加 bulk_sms 方法
+def bulk_sms(self, messages: list, params: dict = {}):
+    results = []
+    for message in messages:
+        to, text = message.get('to'), message.get('text')
+        if to and text:
+            result = self.sms(to, text, params)
+            results.append(result)
+        else:
+            raise ValueError("Each message must have 'to' and 'text' fields.")
+    return results
 
 
 class Sms77api:


### PR DESCRIPTION
This pull request includes a significant change to the `Sms77api.py` file, specifically the addition of a new method for sending bulk SMS messages. The most important changes include the removal of two helper functions and the addition of the `bulk_sms` method.

New functionality:

* [`src/sms77api/Sms77api.py`](diffhunk://#diff-f834f5a65db5aa8ad658e90ff0011e82604ce0912f834c69c5e445e5f76d1a82L13-R23): Added the `bulk_sms` method to send multiple SMS messages in a single call. This method iterates over a list of messages, validates each message, and sends it using the existing `sms` method.

Code cleanup:

* [`src/sms77api/Sms77api.py`](diffhunk://#diff-f834f5a65db5aa8ad658e90ff0011e82604ce0912f834c69c5e445e5f76d1a82L13-R23): Removed the `expect_json` helper function, which was used to determine if a request should expect a JSON response.
* [`src/sms77api/Sms77api.py`](diffhunk://#diff-f834f5a65db5aa8ad658e90ff0011e82604ce0912f834c69c5e445e5f76d1a82L13-R23): Removed the `local_params` helper function, which was used to clean up local parameters.Send SMS in bulk